### PR TITLE
Allow wrapper during config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Provides single module `ng-wrap` with `ngWrap` function `ngWrap(<global name>, l
     angular.module('AppInConfig', ['ng-wrap'])
       .config(function (ngWrapProvider) {
         console.log('wrapping _');
-        ngWrapProvider.wrapper('_');
+        ngWrapProvider.wrap('_');
         // no more window._
         // _ can be injected into other methods now
       })

--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
   ],
   "devDependencies": {
     "angular": "~1.3.3",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "modernizr": "~2.8.3"
   }
 }

--- a/ng-wrap.js
+++ b/ng-wrap.js
@@ -19,9 +19,9 @@ angular.module('ng-wrap', [])
       });
     }
     
-    this.wrapper = wrapper;
-
     return {
+      wrap: wrapper,
+
       $get: function () {
         return wrapper;
       }

--- a/test/index.html
+++ b/test/index.html
@@ -5,6 +5,7 @@
   <title>ng-wrap</title>
   <script src="../bower_components/angular/angular.js"></script>
   <script src="../bower_components/lodash/dist/lodash.js"></script>
+  <script src="../bower_components/modernizr/modernizr.js"></script>
   <script src="../ng-wrap.js"></script>
 </head>
 <body ng-app="App">
@@ -18,10 +19,16 @@
         console.log('wrapping _');
         ngWrap('_');
       })
-      .controller('AppController', function ($scope, _) {
+      .config(function(ngWrapProvider) {
+          console.log('wrapping Modernizr');
+          ngWrapProvider.wrap('Modernizr');
+      })
+      .controller('AppController', function ($scope, _, Modernizr) {
         console.log('AppController');
         console.log('injected typeof _ is', typeof _);
         console.log('window._ ?', typeof window._);
+        console.log('injected typeof Modernizr is', typeof Modernizr);
+        console.log('window.Modernizr ?', typeof window.Modernizr);
         $scope.greeting = _.first(['World!', 'foo']);
       });
   </script>


### PR DESCRIPTION
I was unable to use the wrapper during the config phase as mentioned. I think this is the proper patch (as opposed to a3ae37857c2081c567740420f98d36984ec25f5c).

~~Documentation doesn't have to be updated, it works as documented in the `README.md`.~~

Actually I edited this PR and changed `wrapper` to `wrap` during config. This makes more sense. I updated the README and added the case in the `index.html` as well.
